### PR TITLE
Надо парсить БЕЙС, и не выбивать throw error

### DIFF
--- a/frontend/src/main/scala/com/karasiq/nanoboard/frontend/utils/Blobs.scala
+++ b/frontend/src/main/scala/com/karasiq/nanoboard/frontend/utils/Blobs.scala
@@ -29,7 +29,15 @@ object Blobs {
   }
 
   def fromBase64(base64: String, contentType: String = ""): Blob = {
-    fromString(dom.window.atob(base64), contentType)
+    fromString(
+        () ⇒ {
+               try{
+                  return dom.window.atob(base64);    //return base if base64
+               }catch{
+                  return "NOT_BASE_PLACEHOLDER_TEXT";//and do not stop JavaScript, after throw error.
+               }
+        }
+       , contentType)
   }
 
   def saveBlob(blob: Blob, fileName: String): Unit = {


### PR DESCRIPTION
А если не base64 - то return "какую-то строку-заглушку"